### PR TITLE
Nil Pointer Dereference Check in ReadDocument

### DIFF
--- a/cursor_impl.go
+++ b/cursor_impl.go
@@ -163,15 +163,20 @@ func (c *cursor) ReadDocument(ctx context.Context, result interface{}) (Document
 		// Out of data
 		return DocumentMeta{}, WithStack(NoMoreDocumentsError{})
 	}
+	
 	c.resultIndex++
 	var meta DocumentMeta
-	if err := c.conn.Unmarshal(*c.Result[index], &meta); err != nil {
-		// If a cursor returns something other than a document, this will fail.
-		// Just ignore it.
+
+	if c.Result[index] != nil {
+		if err := c.conn.Unmarshal(*c.Result[index], &meta); err != nil {
+			// If a cursor returns something other than a document, this will fail.
+			// Just ignore it.
+		}
+		if err := c.conn.Unmarshal(*c.Result[index], result); err != nil {
+			return DocumentMeta{}, WithStack(err)
+		}
 	}
-	if err := c.conn.Unmarshal(*c.Result[index], result); err != nil {
-		return DocumentMeta{}, WithStack(err)
-	}
+
 	return meta, nil
 }
 


### PR DESCRIPTION
Would previously crash when reading results for query that was effectively `RETURN null` due to a nil pointer dereference.  Now checks for potential nil value.